### PR TITLE
Revert "build(deps): bump updatecli/updatecli-action from 2.96.0 to 2.99.0"

### DIFF
--- a/.github/workflows/dependanot.yaml
+++ b/.github/workflows/dependanot.yaml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install Updatecli
-        uses: updatecli/updatecli-action@v2.99.0
+        uses: updatecli/updatecli-action@v2.96.0
 
       - name: Install Requirements
         run: |


### PR DESCRIPTION
Reverts lsdopen/.github#54